### PR TITLE
fixed issue #6

### DIFF
--- a/docs/tutorial_docs/simple_zeppy.ipynb
+++ b/docs/tutorial_docs/simple_zeppy.ipynb
@@ -47,6 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# from ppipes.py\n",
     "def waitsome(seconds):\n",
     "    \"\"\"wait for some seconds\"\"\"\n",
     "    time.sleep(seconds)\n",
@@ -62,22 +63,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "time to run this = 9.007 seconds\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "waitlist = [1, 2, 3, 2, 1]\n",
     "starttime = time.time()\n",
     "for seconds in waitlist:\n",
-    "    waitsome(seconds)\n",
+    "    ppipes.waitsome(seconds)\n",
     "endtime = time.time()\n",
     "print(f'time to run this = {(endtime-starttime):.3f} seconds')"
    ]
@@ -92,14 +85,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "time to run this = 3.412 seconds\n",
+      "time to run this = 3.488 seconds\n",
       "[1, 2, 3, 2, 1]\n"
      ]
     }
@@ -107,7 +100,7 @@
    "source": [
     "waitlist = [1, 2, 3, 2, 1] \n",
     "starttime = time.time()\n",
-    "result = ppipes.ipc_parallelpipe(waitsome, waitlist)    \n",
+    "result = ppipes.ipc_parallelpipe(ppipes.waitsome, waitlist)    \n",
     "endtime = time.time()\n",
     "print(f'time to run this = {(endtime-starttime):.3f} seconds')\n",
     "print(result)"
@@ -123,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -136,20 +129,20 @@
       "started worker 3\n",
       "started worker 4\n",
       "starting sink\n",
-      "number of calculations = 5\n",
       "started ventilator\n",
-      "running item: 0, in worker: 0\n",
-      "running item: 2, in worker: 1\n",
-      "running item: 3, in worker: 2\n",
+      "time to run this = 3.456 secondsnumber of calculations = 5\n",
+      "Total taken time for all calcs: 3356 msec\n",
       "running item: 4, in worker: 3\n",
-      "sent result of item: 0, in worker: 0 to sink\n",
-      "running item: 1, in worker: 0\n",
       "sent result of item: 4, in worker: 3 to sink\n",
-      "sent result of item: 3, in worker: 2 to sink\n",
-      "sent result of item: 1, in worker: 0 to sink\n",
-      "Total taken time for all calcs: 3322 msec\n",
-      "sent result of item: 2, in worker: 1 to sink\n",
-      "time to run this = 3.425 seconds\n",
+      "running item: 0, in worker: 2\n",
+      "sent result of item: 0, in worker: 2 to sink\n",
+      "running item: 1, in worker: 2\n",
+      "sent result of item: 1, in worker: 2 to sink\n",
+      "running item: 3, in worker: 1\n",
+      "sent result of item: 3, in worker: 1 to sink\n",
+      "running item: 2, in worker: 0\n",
+      "sent result of item: 2, in worker: 0 to sink\n",
+      "\n",
       "result = [1, 2, 3, 2, 1]\n"
      ]
     }
@@ -157,7 +150,7 @@
    "source": [
     "waitlist = [1, 2, 3, 2, 1] \n",
     "starttime = time.time()\n",
-    "result = ppipes.ipc_parallelpipe(waitsome, waitlist, verbose=True)    \n",
+    "result = ppipes.ipc_parallelpipe(ppipes.waitsome, waitlist, verbose=True)    \n",
     "endtime = time.time()\n",
     "print(f'time to run this = {(endtime-starttime):.3f} seconds')\n",
     "print(f'result = {result}')"
@@ -180,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -190,20 +183,20 @@
       "started worker 0\n",
       "started worker 1\n",
       "starting sink\n",
-      "number of calculations = 5\n",
       "started ventilator\n",
-      "running item: 0, in worker: 0\n",
-      "running item: 2, in worker: 1\n",
+      "time to run this = 5.247 secondsrunning item: 0, in worker: 0\n",
       "sent result of item: 0, in worker: 0 to sink\n",
       "running item: 1, in worker: 0\n",
       "sent result of item: 1, in worker: 0 to sink\n",
       "running item: 3, in worker: 0\n",
+      "sent result of item: 3, in worker: 0 to sink\n",
+      "running item: 2, in worker: 1\n",
       "sent result of item: 2, in worker: 1 to sink\n",
       "running item: 4, in worker: 1\n",
       "sent result of item: 4, in worker: 1 to sink\n",
-      "sent result of item: 3, in worker: 0 to sink\n",
-      "Total taken time for all calcs: 5178 msec\n",
-      "time to run this = 5.234 seconds\n",
+      "number of calculations = 5\n",
+      "Total taken time for all calcs: 5166 msec\n",
+      "\n",
       "[1, 2, 3, 2, 1]\n"
      ]
     }
@@ -211,7 +204,7 @@
    "source": [
     "waitlist = [1, 2, 3, 2, 1] \n",
     "starttime = time.time()\n",
-    "result = ppipes.ipc_parallelpipe(waitsome, waitlist, verbose=True, nworkers=2)    \n",
+    "result = ppipes.ipc_parallelpipe(ppipes.waitsome, waitlist, verbose=True, nworkers=2)    \n",
     "endtime = time.time()\n",
     "print(f'time to run this = {(endtime-starttime):.3f} seconds')\n",
     "print(result)"
@@ -228,10 +221,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "# from ppipes.py\n",
     "def wait_add(first, second):\n",
     "    \"\"\"wait for the sum of first and second. return the sum\"\"\"\n",
     "    seconds = first + second\n",
@@ -247,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -260,28 +254,28 @@
       "started worker 3\n",
       "started worker 4\n",
       "starting sink\n",
-      "number of calculations = 5\n",
       "started ventilator\n",
-      "running item: 0, in worker: 0\n",
-      "running item: 2, in worker: 1\n",
-      "running item: 3, in worker: 2\n",
-      "running item: 4, in worker: 3\n",
+      "time to run this = 3.466 secondsrunning item: 0, in worker: 0\n",
       "sent result of item: 0, in worker: 0 to sink\n",
       "running item: 1, in worker: 0\n",
-      "sent result of item: 4, in worker: 3 to sink\n",
-      "sent result of item: 3, in worker: 2 to sink\n",
       "sent result of item: 1, in worker: 0 to sink\n",
-      "sent result of item: 2, in worker: 1 to sink\n",
-      "Total taken time for all calcs: 3341 msec\n",
-      "time to run this = 3.422 seconds\n",
-      "[1, 2, 3, 2, 1]\n"
+      "number of calculations = 5\n",
+      "Total taken time for all calcs: 3200 msec\n",
+      "running item: 3, in worker: 3\n",
+      "sent result of item: 3, in worker: 3 to sink\n",
+      "running item: 4, in worker: 2\n",
+      "sent result of item: 4, in worker: 2 to sink\n",
+      "\n",
+      "[1, 2, 3, 2, 1]\n",
+      "running item: 2, in worker: 1\n",
+      "sent result of item: 2, in worker: 1 to sink\n"
      ]
     }
    ],
    "source": [
     "waitlist = [(1, 0), (1, 1), (2, 1), (2, 0), (0, 1)] \n",
     "starttime = time.time()\n",
-    "result = ppipes.ipc_parallelpipe(wait_add, waitlist, verbose=True)    \n",
+    "result = ppipes.ipc_parallelpipe(ppipes.wait_add, waitlist, verbose=True)    \n",
     "endtime = time.time()\n",
     "print(f'time to run this = {(endtime-starttime):.3f} seconds')\n",
     "print(result)"
@@ -304,10 +298,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
+    "# from ppipes.py\n",
     "def wait_add_mult(first, add=0, mult=1):\n",
     "    \"\"\"calculate the result=(first+add)*mult. Then waitsome(result)\"\"\"\n",
     "    result=(first + add) * mult\n",
@@ -345,7 +340,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -357,18 +352,18 @@
       "started worker 2\n",
       "started worker 3\n",
       "starting sink\n",
-      "number of calculations = 4\n",
       "started ventilator\n",
-      "running item: 0, in worker: 0\n",
-      "running item: 2, in worker: 1\n",
-      "running item: 3, in worker: 2\n",
+      "[4, 3, 9, 9]running item: 0, in worker: 0\n",
       "sent result of item: 0, in worker: 0 to sink\n",
       "running item: 1, in worker: 0\n",
       "sent result of item: 1, in worker: 0 to sink\n",
+      "number of calculations = 4\n",
+      "Total taken time for all calcs: 9321 msec\n",
+      "running item: 3, in worker: 3\n",
+      "sent result of item: 3, in worker: 3 to sink\n",
+      "running item: 2, in worker: 1\n",
       "sent result of item: 2, in worker: 1 to sink\n",
-      "sent result of item: 3, in worker: 2 to sink\n",
-      "Total taken time for all calcs: 9459 msec\n",
-      "[4, 3, 9, 9]\n"
+      "\n"
      ]
     }
    ],
@@ -379,7 +374,7 @@
     "        {'args':(1,), 'kwargs':{'add':2, 'mult':3}},\n",
     "        {'args': (1, 2, 3)},\n",
     "    ]\n",
-    "    func = wait_add_mult\n",
+    "    func = ppipes.wait_add_mult\n",
     "    result = ppipes.ipc_parallelpipe(func, waitlist, nworkers=None, verbose=True)\n",
     "    print(result)\n"
    ]
@@ -394,7 +389,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -408,7 +403,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,8 +8,8 @@ coverage==4.5.4
 Sphinx
 twine==1.14.0
 
-pytest==4.6.5
-pytest-runner==5.1
+pytest
+pytest-runner
 
 # ---
 jupyter

--- a/zeppy/ppipes.py
+++ b/zeppy/ppipes.py
@@ -182,7 +182,7 @@ def _zmq_vent(args_list, verbose=False, sleeptime=0.1, sinkipc=None, ventipc=Non
         sender.send_pyobj((i, task))
 
         # Give 0MQ time to deliver - otherwise all of it will go to one worker
-        print(f"sleeptime={sleeptime}")
+        # print(f"sleeptime={sleeptime}")
         time.sleep(sleeptime)
 
 


### PR DESCRIPTION
:Problem: tutorials are not running when using python3.10 in jupyter notebook :Solution: updated the tutorial so that they work with python3.10

Details:

- running jupyter notebook is like running the code in an interpreter.
- multiprocessing is not able to run functions defined in the interpreter such as `waitsome`
- These functions are also defined in ppipes.py They can be imported from ppipes and then the tutorial runs without any problems.
- For some reason, this issue kicked in with python3.10